### PR TITLE
feat: Add missing React imports

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,7 +2,7 @@
  * @license
  * SPDX-License-Identifier: Apache-2.0
 */
-import {useEffect, useState, useCallback, useRef} from 'react'
+import React, {useEffect, useState, useCallback, useRef} from 'react'
 import shuffle from 'lodash.shuffle'
 import c from 'clsx'
 import modes from '../lib/modes'

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -2,7 +2,7 @@
  * @license
  * SPDX-License-Identifier: Apache-2.0
 */
-import {useState, useRef, useEffect} from 'react'
+import React, {useState, useRef, useEffect} from 'react'
 import c from 'clsx'
 import useStore from '../lib/store'
 import {

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -2,7 +2,7 @@
  * @license
  * SPDX-License-Identifier: Apache-2.0
 */
-import {useState} from 'react'
+import React, {useState} from 'react'
 import c from 'clsx'
 import {addRound, removeRound} from '../lib/actions'
 import modes from '../lib/modes'

--- a/src/components/FullScreenViewer.jsx
+++ b/src/components/FullScreenViewer.jsx
@@ -2,7 +2,7 @@
  * @license
  * SPDX-License-Identifier: Apache-2.0
 */
-import {useEffect} from 'react'
+import React, {useEffect} from 'react'
 
 export default function FullScreenViewer({htmlContent, onClose}) {
   useEffect(() => {

--- a/src/components/Intro.jsx
+++ b/src/components/Intro.jsx
@@ -2,7 +2,7 @@
  * @license
  * SPDX-License-Identifier: Apache-2.0
 */
-import {useState} from 'react'
+import React, {useState} from 'react'
 import shuffle from 'lodash.shuffle'
 import modes from '../lib/modes'
 import {

--- a/src/components/ModelOutput.jsx
+++ b/src/components/ModelOutput.jsx
@@ -2,7 +2,7 @@
  * @license
  * SPDX-License-Identifier: Apache-2.0
 */
-import {useEffect, useState, memo} from 'react'
+import React, {useEffect, useState, memo} from 'react'
 import SyntaxHighlighter from 'react-syntax-highlighter'
 import * as styles from 'react-syntax-highlighter/dist/esm/styles/hljs'
 import c from 'clsx'

--- a/src/components/Renderer.jsx
+++ b/src/components/Renderer.jsx
@@ -2,7 +2,7 @@
  * @license
  * SPDX-License-Identifier: Apache-2.0
 */
-import {memo, useEffect, useRef, useState} from 'react'
+import React, {memo, useEffect, useRef, useState} from 'react'
 
 function Renderer({mode, code, onViewFullScreen}) {
   const iframeRef = useRef(null)


### PR DESCRIPTION
This commit fixes a `ReferenceError: React is not defined` by adding `import React from 'react'` to all JSX files. This ensures that the `React` object is in scope when the JSX is transpiled to `React.createElement` calls.